### PR TITLE
リクエスト単位でのテンプレートファイルの切り替え

### DIFF
--- a/samples/scala/app/controllers/Application.scala
+++ b/samples/scala/app/controllers/Application.scala
@@ -5,7 +5,7 @@ import jp.furyu.play.velocity.mvc.VM
 
 object Application extends Controller {
 
-  def index = Action {
+  def index = Action { implicit request =>
     val args = Map(
       "name" -> "hoge",
       "link" -> new LinkTool,
@@ -16,14 +16,14 @@ object Application extends Controller {
     Ok(VM("vm/template.vm", args))
   }
 
-  def index2(kind: String, index: Int) = Action {
+  def index2(kind: String, index: Int) = Action { implicit request =>
     val args = Map(
       "kind" -> kind,
       "index" -> index)
     Ok(VM("vm/template2.vm", args))
   }
 
-  def index3 = Action {
+  def index3 = Action { implicit request =>
     Ok(VM("vm/template3.vm"))
   }
 }
@@ -35,3 +35,10 @@ class LinkTool() {
 }
 
 case class User(id: Long, name: String)
+
+class ResourceFinderImpl extends jp.furyu.play.velocity.ResourceFinder {
+  def find(request: RequestHeader, resourceName: String): String = {
+    jp.furyu.play.velocity.VelocityPlugin.Logger.trace("ResourceFinderImpl#find resourceName[%s], request.uri[%s]".format(resourceName, request.uri))
+    resourceName
+  }
+}

--- a/samples/scala/conf/application.conf
+++ b/samples/scala/conf/application.conf
@@ -1,0 +1,12 @@
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
+
+# Root logger:
+logger.root=TRACE
+
+# Logger used by the framework:
+logger.play=TRACE
+
+# Logger provided to your application:
+logger.application=TRACE

--- a/samples/scala/conf/velocity_plugin.properties
+++ b/samples/scala/conf/velocity_plugin.properties
@@ -21,3 +21,12 @@ file.resource.loader.path = samples/scala
 # Allows alternative introspection and all that can of worms brings.
 # ----------------------------------------------------------------------------
 runtime.introspector.uberspect = jp.furyu.play.velocity.ScalaUberspect
+
+# ----------------------------------------------------------------------------
+# RESOURCE MANAGEMENT
+# ----------------------------------------------------------------------------
+# Allows alternative ResourceManager and ResourceCache implementations
+# to be plugged in.
+# ----------------------------------------------------------------------------
+resource.manager.class = jp.furyu.play.velocity.RequestRewritableResourceManagerImpl
+resource.finder.class = controllers.ResourceFinderImpl


### PR DESCRIPTION
リクエスト単位で、評価する（読み込む）テンプレートファイルを切り替えるようにする。
これにより、リクエストから得られる情報（ユーザエージェント等）により表示するテンプレートファイルを動的に切り替えられる。

使い方は、クライアント側が切り替えるロジックを `jp.furyu.play.velocity.ResourceFinder` をmix-inしたクラスで定義し、設定ファイルにてそのクラスを指定する。
`VM`関数に `play.api.mvc.RequestHeader` を渡さないとならなくなった点で、互換性の問題があるのが懸念点。
